### PR TITLE
Fix LocalForage dependency in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "typescript": "^2.0.3"
   },
   "dependencies": {
-    "localforage": ">=1.4.0"
+    "localforage": ">=1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "typescript": "^2.0.3"
   },
   "dependencies": {
-    "localforage": ">=1.6.0"
+    "localforage": "^1.4.0"
   }
 }


### PR DESCRIPTION
localForage has been recently bumped to `1.6.0`. This PR ensures that localForage-getItems can work with it without crashing. This is a very small change, though without it no localForage package above `1.5.3` could work without crashing.