### PR TITLE
Fix test script command on windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prebuild": "eslint lib test",
     "build": "rollup -c rollup.config.umd.js && rollup -c rollup.config.es6.js",
     "pretest": "rollup -c rollup.config.test.js",
-    "test": "mocha build/test-bundle.js && node_modules/.bin/tsc --project typing-tests",
+    "test": "mocha build/test-bundle.js && tsc --project typing-tests",
     "prepublish": "npm run build && npm test"
   },
   "repository": {


### PR DESCRIPTION
The path is unnecessary and causes the command to fail on windows.